### PR TITLE
Fix tamed xenomorph egg registration

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,5 @@
 mobs:register_mob("mobs_xenomorph:xenomorph", {
-	type = "monster",
+	type = "animal",
 	passive = false,
 	reach = 4,
 	damage = 4,
@@ -50,6 +50,11 @@ mobs:register_mob("mobs_xenomorph:xenomorph", {
 		punch_start = 30,
 		punch_end = 59,
 	},
+	after_activate = function(self)
+		if not self.tamed then
+			self.type = "monster"
+		end
+	end,
 	do_custom = function(self, dtime)
 		if not self.v2 then
 			self.v2 = 0


### PR DESCRIPTION
In the recent update of mobs_redo API, the registration of eggs for tamed mobs was removed for `monster` type of mobs. And so all tamed xenomorph eggs became unknown items.
This PR forces API to register tamed xenomorph egg by setting initial type to `animal`. To keep untamed xenomorph hostile, the `self.type` is automatically set to `monster` in the the `after_activate` function.
### How to test
* Spawn or find a xenomorph
  * Walk around or punch xenomorph to ensure that it's hostile (remember to revoke `peaceful_player` priv)
* Use a bunch of `default:mese` to tame it
* Once tamed, use lasso to pick it to inventory
* It should be named as `xenomorph (Tamed)` and have fire icon in the inventory.